### PR TITLE
Fix Azure National Cloud authentication using token (RBAC) (Generated by Ana - AI SDE)

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -139,7 +139,7 @@ def _get_search_client(
     else:
         credential = DefaultAzureCredential()
     index_client: SearchIndexClient = SearchIndexClient(
-        endpoint=endpoint, credential=credential, user_agent=user_agent
+        endpoint=endpoint, credential=credential, user_agent=user_agent, **additional_search_client_options
     )
     try:
         index_client.get_index(name=index_name)


### PR DESCRIPTION
This pull request addresses the issue with authenticating Azure National Cloud using token (RBAC) in the AzureSearch vectorstore implementation.

## Changes

- Modified the `_get_search_client` method in `azuresearch.py` to pass `additional_search_client_options` to the `SearchIndexClient` instance.

## Implementation Details

The patch updates the `SearchIndexClient` initialization to include the `additional_search_client_options` parameter:

```python
index_client: SearchIndexClient = SearchIndexClient(
    endpoint=endpoint,
    credential=credential,
    user_agent=user_agent,
    **additional_search_client_options
)
```

This change allows the `audience` parameter to be correctly passed when using Azure National Cloud, fixing the authentication issues with GovCloud & RBAC.

This patch was generated by [Ana - AI SDE](https://openana.ai/), an AI-powered software development assistant.

This is a fix for [Issue 25823](https://github.com/langchain-ai/langchain/issues/25823)